### PR TITLE
Spec Generator Improvements

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -38,8 +38,8 @@ export default class IpseityProcessor {
       if (opt.page?.date) opt.lastModified = opt.page.date;
       else opt.lastModified = new Date();
     }
-    const citesFile = join(this.output, `.well-known/ipseity/references.json`);
-    const defsPath = join(this.output, `.well-known/ipseity/definitions/`);
+    const citesFile = join(this.output, `.well-known/spec-generator/references.json`);
+    const defsPath = join(this.output, `.well-known/spec-generator/definitions/`);
     await mkdir(defsPath, { recursive: true });
     const quietMode = this.quietMode;
     const ctx = {

--- a/lib/process.js
+++ b/lib/process.js
@@ -111,6 +111,8 @@ export default class IpseityProcessor {
     const defsMeta = definitionsToWebRef(ctx.definitions, doc.title, url);
     await saveJSON(ctx.citesFile, cites);
     await saveJSON(join(ctx.defsPath, `${shortName}.json`), defsMeta);
+    const linkCanonical = doc.querySelector('link[rel=canonical]');
+    if (linkCanonical) linkCanonical.href = url;
     return dom.serialize();
   }
 

--- a/lib/reference-manager.js
+++ b/lib/reference-manager.js
@@ -10,10 +10,10 @@ const rel = makeRel(import.meta.url);
 const webrefPath = rel('../node_modules/webref/ed/dfns/');
 
 const definitionSources = [
-  'https://specs.ipfs.tech/.well-known/definitions/',
+  'https://specs.ipfs.tech/.well-known/spec-generator/definitions/',
 ];
 const referenceSources = [
-  'https://specs.ipfs.tech/.well-known/references.json',
+  'https://specs.ipfs.tech/.well-known/spec-generator/references.json',
 ];
 // these are meant to be global and used as a singleton
 const allDefinitions = {};

--- a/test/fixtures/template.html
+++ b/test/fixtures/template.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
     <title></title>
+    <link rel="canonical">
     <link rel="stylesheet" href="/css/specs.css">
     <link rel="icon" href="/img/ipfs-standards.svg">
   </head>

--- a/test/process.js
+++ b/test/process.js
@@ -6,6 +6,7 @@ import { JSDOM } from 'jsdom';
 import makeSelectron from 'selectron-test';
 import IpseityProcessor from '../lib/process.js';
 import makeRel from '../lib/rel.js';
+import assert from 'assert'
 
 const rel = makeRel(import.meta.url);
 
@@ -38,6 +39,11 @@ describe('General MD/HTML Processing', function () {
     selectron('h1', 'The fun spec');
     selectron('h1 > code', 'fun');
     selectron('title', 'The fun spec');
+  });
+  it('sets canonical link', async() => {
+    const doc = await md2doc('# The `fun` spec');
+    const link = doc.querySelector('link[rel=canonical]');
+    assert.equal(link.href, 'https://berjon.com/permalink');
   });
   it('sets the date', async () => {
     const bd = '1977-03-15T08:42:00.000Z';
@@ -100,7 +106,7 @@ describe('General MD/HTML Processing', function () {
 async function md2doc (md, opt = {}) {
   const template = rel('fixtures/template.html');
   const output = await mkdtemp(join(tmpdir(), 'ipseity-'));
-  opt.page = { inputPath: output };
+  opt.page = { inputPath: output, url: 'permalink' };
   opt.editors = [];
   const ips = new IpseityProcessor({ template, output, baseURL: 'https://berjon.com/' });
   const html = await ips.render(md, opt);

--- a/test/run.js
+++ b/test/run.js
@@ -47,7 +47,7 @@ describe('Full Run', function () {
     selectron('a[href="#dfn-Frontmatter"][data-dfn-type="dfn"]', 'frontmatter');
   });
   it('outputs references', async () => {
-    const refs = JSON.parse(await readFile(rel('fixtures/out/.well-known/ipseity/references.json')));
+    const refs = JSON.parse(await readFile(rel('fixtures/out/.well-known/spec-generator/references.json')));
     const sfs = refs['spec-for-specs'];
     ok(sfs, 'has a spec-for-specs entry');
     equal(sfs.title, 'Spec for Specs', 'title is correct');
@@ -56,7 +56,7 @@ describe('Full Run', function () {
     equal(sfs.href, 'https://berjon.com/specs/spec-for-specs/', 'href is correct');
   });
   it('outputs definitions', async () => {
-    const refs = JSON.parse(await readFile(rel('fixtures/out/.well-known/ipseity/definitions/spec-for-specs.json')));
+    const refs = JSON.parse(await readFile(rel('fixtures/out/.well-known/spec-generator/definitions/spec-for-specs.json')));
     equal(refs.spec.title, 'Spec for Specs', 'title is correct');
     equal(refs.spec.url, 'https://berjon.com/specs/spec-for-specs/', 'url is correct');
     const dfns = refs.dfns.filter(d => d.id === 'dfn-spec');


### PR DESCRIPTION
- [ff23ef1](https://github.com/darobin/spec-generator/pull/1/commits/ff23ef1e0a2a20b16434d9af753191912e58d889) fixes the output references and definitions path to be consistent https://github.com/darobin/spec-generator/blob/4b761ba821aaed5cc5d573e968ff80c4417afecf/lib/reference-manager.js#L12-L17
- [9b36c99](https://github.com/darobin/spec-generator/pull/1/commits/9b36c994e225f51257fb1fed787a669ab897c608) adds support canonical links. If you add `<link rel="canonical">` to your template, its `href` will be filled with the canonical link.

Feel free to cherry-pick and change things.