### PR TITLE
feat: use title and description for rendering

### DIFF
--- a/lib/html/header-material.js
+++ b/lib/html/header-material.js
@@ -16,12 +16,22 @@ const maturityColours = {
 export default async function run (doc, opt, ctx) {
   const el = makeEl(doc);
   let h1 = doc.querySelector('h1');
-  if (!h1) {
+  if (opt.title) {
+    h1 = el('h1', {}, [opt.title])
+  } else {
     h1 = el('h1', {}, ['Untitled']);
-    ctx.error(`Document does not have a title, you need to add a '# My Doc' near the top.`);
+    ctx.error(`Document does not have a title, you need to add a 'title: My Doc' in the frontmatter.`);
   }
   h1.setAttribute('id', 'title');
   doc.title = h1.textContent;
+  if (opt.description) {
+    const description = doc.querySelector('meta[name="description"]')
+    if (!description) {
+      ctx.error('Template file should contain a <meta> tag for the description.')
+    } else {
+      description.setAttribute('content', opt.description.replaceAll('\n', ' ').trim())
+    }
+  }
   const lm = opt.lastModified;
   const pDate = el('p', { id: 'last-modified' }, [
     el('time', { datetime: lm.toISOString() }, [`${lm.getUTCDate()} ${months[lm.getUTCMonth()]} ${lm.getUTCFullYear()}`])
@@ -124,7 +134,8 @@ export default async function run (doc, opt, ctx) {
   }
   const dl = metaEls.length ? el('dl', null, metaEls) : null;
   const abstractContent = [];
-  let nxt = h1;
+  let nxt = doc.querySelector('ipseity-header + *');
+  abstractContent.push(nxt);
   while (nxt.nextSibling) {
     nxt = nxt.nextSibling;
     if (nxt.nodeType == 1 && /^h\d/i.test(nxt.localName)) break;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -41,6 +41,7 @@ export default class IpseityRunner {
         config.addPassthroughCopy(`${pthrough}/**/*.woff2`);
         config.addPassthroughCopy(`${pthrough}/**/*.ttf`);
         config.addFilter('permalink', url => `${baseURL}${url}`);
+        config.addFilter('singleLine', str => str.replace('\n', ' ').trim());
         // config.setUseGitIgnore(false); // don't know if we'll need this
         const processor = new IpseityProcessor({ template, output, baseURL, quietMode, github });
         config.ignores.add('README.md');


### PR DESCRIPTION
Closes #11.

This is a simple change that uses the frontmatter title and description fields for the... title and description. This will allow us to use other tools from Eleventy, such as automatically generating lists.